### PR TITLE
Add incremental builds and fix link checker scope

### DIFF
--- a/src/build-cache.ts
+++ b/src/build-cache.ts
@@ -1,0 +1,87 @@
+/** Build cache — tracks file mtimes for incremental builds */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { ScanEntry } from './types';
+
+export interface BuildCacheEntry {
+  relativePath: string;
+  mtime: string;
+  size: number;
+}
+
+export interface BuildCache {
+  version: 1;
+  builtAt: string;
+  entries: BuildCacheEntry[];
+}
+
+const CACHE_FILE = '.claude-glass-cache.json';
+
+function cachePath(outputDir: string, prefix: string): string {
+  return join(outputDir, prefix, CACHE_FILE);
+}
+
+export function readBuildCache(outputDir: string, prefix: string): BuildCache | null {
+  const path = cachePath(outputDir, prefix);
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'));
+    if (data.version !== 1) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function writeBuildCache(outputDir: string, prefix: string, entries: ScanEntry[]): void {
+  const cache: BuildCache = {
+    version: 1,
+    builtAt: new Date().toISOString(),
+    entries: entries.map(e => ({
+      relativePath: e.relativePath,
+      mtime: e.mtime.toISOString(),
+      size: e.size,
+    })),
+  };
+  writeFileSync(cachePath(outputDir, prefix), JSON.stringify(cache, null, 2) + '\n');
+}
+
+/**
+ * Compare current scan entries against cached entries.
+ * Returns { changed, added, removed, unchanged } file lists.
+ */
+export function diffEntries(
+  current: ScanEntry[],
+  cache: BuildCache
+): {
+  changed: ScanEntry[];
+  added: ScanEntry[];
+  removed: string[];
+  unchanged: ScanEntry[];
+} {
+  const cacheMap = new Map(cache.entries.map(e => [e.relativePath, e]));
+  const changed: ScanEntry[] = [];
+  const added: ScanEntry[] = [];
+  const unchanged: ScanEntry[] = [];
+
+  for (const entry of current) {
+    const cached = cacheMap.get(entry.relativePath);
+    if (!cached) {
+      added.push(entry);
+    } else if (
+      entry.mtime.toISOString() !== cached.mtime ||
+      entry.size !== cached.size
+    ) {
+      changed.push(entry);
+    } else {
+      unchanged.push(entry);
+    }
+    cacheMap.delete(entry.relativePath);
+  }
+
+  // Remaining in cacheMap were removed
+  const removed = [...cacheMap.keys()];
+
+  return { changed, added, removed, unchanged };
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -16,7 +16,8 @@ import { renderPage } from './templates/layout';
 import { renderLandingPage } from './templates/landing';
 import { readManifest, writeManifest, updateManifest, deriveName, nameToPrefix } from './manifest';
 import { checkLinks } from './link-checker';
-import { mkdirSync, writeFileSync, copyFileSync, existsSync } from 'fs';
+import { readBuildCache, writeBuildCache, diffEntries } from './build-cache';
+import { mkdirSync, writeFileSync, copyFileSync, existsSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import type { BuildConfig, ProcessedFile, ScanEntry } from './types';
 
@@ -45,6 +46,33 @@ export async function build(config: BuildConfig): Promise<void> {
   if (entries.length === 0) {
     console.error('No files found. Is this a .claude directory?');
     return;
+  }
+
+  // Incremental check: compare against build cache
+  if (config.incremental) {
+    const cache = readBuildCache(config.outputDir, prefix);
+    if (cache) {
+      const diff = diffEntries(entries, cache);
+      const hasChanges = diff.changed.length > 0 || diff.added.length > 0 || diff.removed.length > 0;
+
+      if (!hasChanges) {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        console.log(`No changes detected (${entries.length} files unchanged). Skipping build. (${elapsed}s)`);
+        return;
+      }
+
+      console.log(`Incremental: ${diff.changed.length} changed, ${diff.added.length} added, ${diff.removed.length} removed, ${diff.unchanged.length} unchanged`);
+
+      // Clean up removed files from output
+      for (const removedPath of diff.removed) {
+        const outputFile = join(prefixDir, removedPath.replace(/\.md$/, '/index.html').replace(/\.json$/, '.html'));
+        if (existsSync(outputFile)) {
+          try { unlinkSync(outputFile); } catch { /* ignore */ }
+        }
+      }
+    } else {
+      console.log('Incremental: no cache found, doing full build');
+    }
   }
 
   // Phase 2: Process
@@ -153,20 +181,25 @@ export async function build(config: BuildConfig): Promise<void> {
   const landingHtml = renderLandingPage(updatedManifest);
   writeFileSync(join(config.outputDir, 'index.html'), landingHtml);
 
-  // Phase 6: Check for broken links (use root outputDir so absolute /prefix/ links resolve)
-  const { total, broken } = checkLinks(config.outputDir);
-  if (broken.length > 0) {
-    console.log(`\nLinks: ${total} total, ${broken.length} broken`);
-    const uniqueTargets = [...new Set(broken.map(b => b.href))].slice(0, 20);
-    for (const href of uniqueTargets) {
-      const count = broken.filter(b => b.href === href).length;
-      console.log(`  ✗ ${href} (${count} page${count > 1 ? 's' : ''})`);
+  // Write build cache for next incremental run
+  writeBuildCache(config.outputDir, prefix, entries);
+
+  // Phase 6: Check for broken links (only within this site's prefix dir)
+  if (!config.noLinkCheck) {
+    const { total, broken } = checkLinks(prefixDir);
+    if (broken.length > 0) {
+      console.log(`\nLinks: ${total} total, ${broken.length} broken`);
+      const uniqueTargets = [...new Set(broken.map(b => b.href))].slice(0, 20);
+      for (const href of uniqueTargets) {
+        const count = broken.filter(b => b.href === href).length;
+        console.log(`  ✗ ${href} (${count} page${count > 1 ? 's' : ''})`);
+      }
+      if (uniqueTargets.length < [...new Set(broken.map(b => b.href))].length) {
+        console.log(`  ... and ${[...new Set(broken.map(b => b.href))].length - uniqueTargets.length} more`);
+      }
+    } else {
+      console.log(`Links: ${total} checked, all OK`);
     }
-    if (uniqueTargets.length < [...new Set(broken.map(b => b.href))].length) {
-      console.log(`  ... and ${[...new Set(broken.map(b => b.href))].length - uniqueTargets.length} more`);
-    }
-  } else {
-    console.log(`Links: ${total} checked, all OK`);
   }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,8 @@ function parseArgs(args: string[]): { command: string; config: BuildConfig } {
   let host = '127.0.0.1';
   let noSearch = false;
   let noMemory = false;
+  let noLinkCheck = false;
+  let incremental = false;
   const exclude: string[] = [];
   let verbose = false;
   let name = '';
@@ -40,6 +42,10 @@ function parseArgs(args: string[]): { command: string; config: BuildConfig } {
       noSearch = true;
     } else if (arg === '--no-memory') {
       noMemory = true;
+    } else if (arg === '--no-link-check') {
+      noLinkCheck = true;
+    } else if (arg === '--incremental') {
+      incremental = true;
     } else if (arg === '--exclude') {
       exclude.push(args[++i] || '');
     } else if (arg === '--name') {
@@ -62,7 +68,7 @@ function parseArgs(args: string[]): { command: string; config: BuildConfig } {
 
   return {
     command,
-    config: { inputDir, outputDir, port, host, noSearch, noMemory, exclude, verbose, name },
+    config: { inputDir, outputDir, port, host, noSearch, noMemory, noLinkCheck, incremental, exclude, verbose, name },
   };
 }
 
@@ -82,6 +88,8 @@ Options:
   --name <string>        Override project name (default: auto-derived from path)
   --no-search            Skip search index generation
   --no-memory            Exclude MEMORY/ directory tree
+  --no-link-check        Skip broken link checking
+  --incremental          Only rebuild if source files changed
   --exclude <glob>       Additional exclusion pattern (repeatable)
   --verbose              Print processing details
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface BuildConfig {
   host: string;
   noSearch: boolean;
   noMemory: boolean;
+  noLinkCheck: boolean;
+  incremental: boolean;
   exclude: string[];
   verbose: boolean;
   name: string;


### PR DESCRIPTION
## Summary
- **Incremental builds** (`--incremental`): compares file mtimes against a per-site build cache. Skips build entirely when nothing changed (0.0s). Detects changed/added/removed files and reports the diff.
- **`--no-link-check` flag**: skips broken link checking entirely — useful for cron jobs and memory-constrained environments.
- **Link checker scoped to prefix dir**: was scanning ALL sites in the output directory (6.6M links, 2+ minutes), now only scans the current site's prefix dir.

### Performance impact

| Site | Before | After (full) | After (no changes) |
|------|--------|-------------|-------------------|
| posts (13 files) | 121s | 0.2s | 0.0s |
| slipbox (40 files) | 141s | 1.0s | 0.0s |

### Motivation
Three OOM kills on a 3.7GB RAM machine while building large sites. These changes make claude-glass safe for cron job use on memory-constrained systems.

## Test plan
- [ ] `claude-glass build <dir> --incremental` does full build on first run (no cache)
- [ ] Second run with no changes skips build (0.0s)
- [ ] Touch a file, run again — detects 1 changed file, rebuilds
- [ ] `--no-link-check` skips link checking phase
- [ ] Link checker only reports links within the current site prefix
- [ ] Build cache written to `<prefix>/.claude-glass-cache.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)