### PR TITLE
Release v0.7.4

### DIFF
--- a/.dev/release-v0.7.4.md
+++ b/.dev/release-v0.7.4.md
@@ -1,0 +1,41 @@
+# Release Checklist: v0.7.4
+
+**Started:** 2026-04-05 | **Project:** claude-glass
+
+## Current Step: 4. Test Coverage
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Pre-flight | [x] | JS/TS Bun project, 2 commits since v0.7.3 |
+| 1. Security Audit | [x] | 0 blockers, 2 INFO, 1 LOW |
+| 2. Triage Findings | [x] | No blockers or should-fix |
+| 3. Fix Blockers | [x] | Nothing to fix |
+| --- GATE: Security | [x] | PASS |
+| 4. Test Coverage | [ ] | |
+| --- GATE: Quality | [ ] | |
+| 5. Dependency Audit | [ ] | |
+| 6. Documentation Final Pass | [ ] | |
+| 7. Version Bump | [ ] | |
+| 8. Release Notes | [ ] | |
+| 9. PR Creation/Update | [ ] | |
+| 10. Issue Triage | [ ] | |
+| 11. Merge & Verify | [ ] | |
+| --- GATE: CI | [ ] | |
+| 12. Tag & GitHub Release | [ ] | |
+| 13. Post-Release | [ ] | |
+| 14. Branch Cleanup | [ ] | |
+| 15. Retrospective | [ ] | |
+
+## Features Included
+
+- Output directory moved from /tmp to ~/.local/share/claude-glass (XDG-compliant, reboot-safe)
+- Deployment smoke test script (scripts/smoke-test.sh, 14 curl-based checks)
+- Nightly build ntfy notification with status summary
+
+## Findings
+
+<!-- Security audit findings logged here -->
+
+## Detours
+
+<!-- Log unplanned work that happened between steps -->

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ claude-glass build [dir]     Build static site
 claude-glass serve [dir]     Build + serve
 
 Options:
-  --output, -o <path>    Output directory (default: /tmp/claude-glass)
+  --output, -o <path>    Output directory (default: ~/.local/share/claude-glass)
   --name <string>        Override project name (default: auto-derived from path)
   --port, -p <number>    Server port (default: 3333)
   --host <addr>          Bind address (default: 127.0.0.1)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v0.7.4 (2026-04-05)
+
+### Improvements
+
+- **Persistent output directory** — Default output moved from `/tmp/claude-glass` to `~/.local/share/claude-glass` (XDG-compliant). Build artifacts now survive reboots — no more lost sites when systemd-tmpfiles cleans `/tmp`.
+- **Deployment smoke tests** — New `scripts/smoke-test.sh` runs 14 curl-based checks against a live server: homepage, CSS, Pagefind, 404 handling, all site prefixes from manifest, and content verification. Accepts optional URL arg for remote testing.
+- **Nightly build notifications** — `scripts/nightly-build.sh` now sends a summary to ntfy after builds complete, reporting OK/FAIL/SKIP counts per site.
+
+### Quality
+
+- Tests: 21 pass, 0 fail
+- Security: 0 blockers (output dir move is a security improvement — /tmp is world-readable)
+- Dependencies: `bun audit` clean, no vulnerabilities
+
+---
+
 ## v0.7.3 (2026-03-26)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-glass",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Static site generator for browsing Claude Code .claude directories",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Move default output directory from `/tmp/claude-glass` to `~/.local/share/claude-glass` (XDG-compliant, survives reboots)
- Add deployment smoke test script (`scripts/smoke-test.sh`) — 14 curl-based checks
- Add ntfy notification to nightly build script

## Changes

- `src/cli.ts`: Default output dir uses `homedir()` + `/.local/share/claude-glass`
- `scripts/nightly-build.sh`: Updated OUTPUT/LOG paths, added ntfy summary
- `scripts/smoke-test.sh`: New — tests homepage, CSS, Pagefind, 404s, all site prefixes
- `README.md`: Updated default output dir in usage docs
- `package.json`: Version bump 0.7.3 → 0.7.4

## Test plan

- [x] `bun test` — 21/21 pass
- [x] `bun audit` — no vulnerabilities
- [x] `smoke-test.sh` — 14/14 pass (localhost + Tailscale)
- [x] Security audit — 0 blockers

Generated with [Claude Code](https://claude.com/claude-code)