### PR TITLE
Fix prefix handling in index generators and link checker (#15, #16)

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -29,6 +29,7 @@ export async function build(config: BuildConfig): Promise<void> {
   // Resolve project name and prefix
   const name = config.name || deriveName(config.inputDir);
   const prefix = nameToPrefix(name);
+  const baseUrl = '/' + prefix;
   const prefixDir = join(config.outputDir, prefix);
 
   console.log(`Building "${name}" (/${prefix}/) from ${config.inputDir}...`);
@@ -101,9 +102,9 @@ export async function build(config: BuildConfig): Promise<void> {
 
   // Phase 2b: Generate index pages
   const indexes = [
-    generateSkillsIndex(processed),
-    generateHooksIndex(processed),
-    generateAgentsIndex(processed),
+    generateSkillsIndex(processed, baseUrl),
+    generateHooksIndex(processed, baseUrl),
+    generateAgentsIndex(processed, baseUrl),
   ].filter(Boolean) as ProcessedFile[];
 
   processed.push(...indexes);
@@ -115,7 +116,7 @@ export async function build(config: BuildConfig): Promise<void> {
   const navTree = buildNavTree(processed);
 
   // Phase 3b: Generate directory index pages
-  const dirIndexes = generateDirectoryIndexes(processed, navTree);
+  const dirIndexes = generateDirectoryIndexes(processed, navTree, baseUrl);
   if (dirIndexes.length > 0) {
     processed.push(...dirIndexes);
     console.log(`Generated ${dirIndexes.length} directory index pages`);
@@ -125,7 +126,6 @@ export async function build(config: BuildConfig): Promise<void> {
   const pathMap = buildPathMap(
     processed.map((f) => ({ relativePath: f.entry.relativePath, outputPath: f.outputPath }))
   );
-  const baseUrl = '/' + prefix;
   for (const file of processed) {
     file.html = rewriteInternalLinks(file.html, file.entry.relativePath, pathMap, baseUrl);
   }
@@ -215,7 +215,7 @@ export async function build(config: BuildConfig): Promise<void> {
 
   // Phase 7: Check for broken links (only within this site's prefix dir)
   if (!config.noLinkCheck) {
-    const { total, broken } = checkLinks(prefixDir);
+    const { total, broken } = checkLinks(prefixDir, prefix);
     if (broken.length > 0) {
       console.log(`\nLinks: ${total} total, ${broken.length} broken`);
       const uniqueTargets = [...new Set(broken.map(b => b.href))].slice(0, 20);

--- a/src/indexes/agents-index.ts
+++ b/src/indexes/agents-index.ts
@@ -4,7 +4,7 @@ import { escapeHtml, sanitizeColor } from '../processors/markdown';
 import { modelBadge } from '../processors/badges';
 import type { ProcessedFile } from '../types';
 
-export function generateAgentsIndex(files: ProcessedFile[]): ProcessedFile | null {
+export function generateAgentsIndex(files: ProcessedFile[], baseUrl: string = ''): ProcessedFile | null {
   const agents = files.filter(f => f.entry.type === 'agent');
   if (agents.length === 0) return null;
 
@@ -18,7 +18,7 @@ export function generateAgentsIndex(files: ProcessedFile[]): ProcessedFile | nul
       const color = m.color as string || '';
       const personaName = escapeHtml((m['persona.name'] as string) || '');
       const personaTitle = escapeHtml((m['persona.title'] as string) || '');
-      const href = '/' + agent.outputPath;
+      const href = baseUrl + '/' + agent.outputPath;
 
       const safeColor = sanitizeColor(color);
       const colorSwatch = safeColor ? `<span class="color-swatch" style="background-color: ${safeColor}"></span>` : '';

--- a/src/indexes/directory-index.ts
+++ b/src/indexes/directory-index.ts
@@ -7,7 +7,7 @@ import type { ProcessedFile, NavNode } from '../types';
  * Generate index pages for every directory that contains rendered files
  * but doesn't already have its own index page.
  */
-export function generateDirectoryIndexes(files: ProcessedFile[], navTree: NavNode): ProcessedFile[] {
+export function generateDirectoryIndexes(files: ProcessedFile[], navTree: NavNode, baseUrl: string = ''): ProcessedFile[] {
   const existingPaths = new Set(files.map(f => f.outputPath));
   const indexes: ProcessedFile[] = [];
 
@@ -45,10 +45,10 @@ export function generateDirectoryIndexes(files: ProcessedFile[], navTree: NavNod
     for (const child of node.children) {
       if (child.isDirectory) {
         const childCount = countFiles(child);
-        const childHref = encodeURI('/' + child.path + '/index.html');
+        const childHref = encodeURI(baseUrl + '/' + child.path + '/index.html');
         dirs.push(`<li class="dir-item"><a href="${childHref}">📁 ${escapeHtml(child.name)}</a> <span class="dir-count">(${childCount})</span></li>`);
       } else {
-        const href = encodeURI('/' + (child.outputPath || child.path));
+        const href = encodeURI(baseUrl + '/' + (child.outputPath || child.path));
         const displayName = child.title || child.name.replace(/\.(md|ts|json)$/, '');
         fileItems.push(`<li class="file-item"><a href="${href}">${escapeHtml(displayName)}</a></li>`);
       }

--- a/src/indexes/hooks-index.ts
+++ b/src/indexes/hooks-index.ts
@@ -3,7 +3,7 @@
 import { escapeHtml } from '../processors/markdown';
 import type { ProcessedFile } from '../types';
 
-export function generateHooksIndex(files: ProcessedFile[]): ProcessedFile | null {
+export function generateHooksIndex(files: ProcessedFile[], baseUrl: string = ''): ProcessedFile | null {
   const hooks = files.filter(f => f.entry.type === 'hook');
   if (hooks.length === 0) return null;
 
@@ -14,7 +14,7 @@ export function generateHooksIndex(files: ProcessedFile[]): ProcessedFile | null
       const name = escapeHtml(hook.title || 'Unnamed');
       const trigger = escapeHtml((m.trigger as string) || '');
       const purpose = escapeHtml((m.purpose as string || '').slice(0, 120));
-      const href = '/' + hook.outputPath;
+      const href = baseUrl + '/' + hook.outputPath;
 
       return `<tr>
   <td><a href="${href}">${name}</a></td>

--- a/src/indexes/skills-index.ts
+++ b/src/indexes/skills-index.ts
@@ -4,7 +4,7 @@ import { escapeHtml } from '../processors/markdown';
 import { effortBadge, modelBadge } from '../processors/badges';
 import type { ProcessedFile } from '../types';
 
-export function generateSkillsIndex(files: ProcessedFile[]): ProcessedFile | null {
+export function generateSkillsIndex(files: ProcessedFile[], baseUrl: string = ''): ProcessedFile | null {
   const skills = files.filter(f => f.entry.type === 'skill');
   if (skills.length === 0) return null;
 
@@ -28,7 +28,7 @@ export function generateSkillsIndex(files: ProcessedFile[]): ProcessedFile | nul
       const description = escapeHtml((m.description as string || '').slice(0, 100));
       const effort = m.effort as string || '';
       const model = m.model as string || '';
-      const href = '/' + skill.outputPath;
+      const href = baseUrl + '/' + skill.outputPath;
 
       // Find workflow count
       const skillDir = skill.entry.relativePath.replace(/\/SKILL\.md$/, '');

--- a/src/link-checker.ts
+++ b/src/link-checker.ts
@@ -10,7 +10,7 @@ interface LinkResult {
   status: 'ok' | 'broken';
 }
 
-export function checkLinks(outputDir: string): { total: number; broken: LinkResult[] } {
+export function checkLinks(outputDir: string, sitePrefix: string = ''): { total: number; broken: LinkResult[] } {
   const htmlFiles: string[] = [];
   collectHtmlFiles(outputDir, htmlFiles);
 
@@ -36,7 +36,15 @@ export function checkLinks(outputDir: string): { total: number; broken: LinkResu
       // Resolve the target path
       let targetPath: string;
       if (href.startsWith('/')) {
-        targetPath = join(outputDir, href);
+        // If href is site-absolute and already contains the site prefix,
+        // strip the leading /<sitePrefix> segment since outputDir IS the
+        // per-site prefix directory. Otherwise fall through to the legacy
+        // join-against-outputDir behavior.
+        if (sitePrefix && href.startsWith('/' + sitePrefix + '/')) {
+          targetPath = join(outputDir, href.slice(sitePrefix.length + 1));
+        } else {
+          targetPath = join(outputDir, href);
+        }
       } else {
         targetPath = resolve(dirname(file), href);
       }

--- a/src/tests/indexes-prefix.test.ts
+++ b/src/tests/indexes-prefix.test.ts
@@ -1,0 +1,108 @@
+/** Regression tests for issue #16 — index generators must honor baseUrl */
+
+import { describe, test, expect } from 'bun:test';
+import { generateAgentsIndex } from '../indexes/agents-index';
+import { generateSkillsIndex } from '../indexes/skills-index';
+import { generateHooksIndex } from '../indexes/hooks-index';
+import { generateDirectoryIndexes } from '../indexes/directory-index';
+import type { ProcessedFile, NavNode } from '../types';
+
+function mkFile(partial: Partial<ProcessedFile> & { type: ProcessedFile['entry']['type']; outputPath: string; title: string; relativePath: string }): ProcessedFile {
+  return {
+    entry: {
+      absolutePath: '',
+      relativePath: partial.relativePath,
+      type: partial.type,
+      size: 0,
+      mtime: new Date(),
+    },
+    html: partial.html ?? '<p>x</p>',
+    title: partial.title,
+    metadata: partial.metadata ?? {},
+    outputPath: partial.outputPath,
+  };
+}
+
+const BASE = '/flicky';
+
+describe('issue #16 — index generators honor baseUrl', () => {
+  test('generateAgentsIndex prefixes hrefs with baseUrl', () => {
+    const files: ProcessedFile[] = [
+      mkFile({
+        type: 'agent',
+        title: 'Designer',
+        relativePath: 'agents/Designer.md',
+        outputPath: 'agents/Designer/index.html',
+        metadata: { description: 'Visual designer', model: 'opus', color: '#abcdef' },
+      }),
+    ];
+    const result = generateAgentsIndex(files, BASE);
+    expect(result).not.toBeNull();
+    expect(result!.html).toContain('href="/flicky/agents/Designer/index.html"');
+    expect(result!.html).not.toContain('href="/agents/Designer/index.html"');
+  });
+
+  test('generateSkillsIndex prefixes hrefs with baseUrl', () => {
+    const files: ProcessedFile[] = [
+      mkFile({
+        type: 'skill',
+        title: 'Research',
+        relativePath: 'skills/Research/SKILL.md',
+        outputPath: 'skills/Research/SKILL/index.html',
+        metadata: { description: 'Do research', effort: 'medium', model: 'sonnet' },
+      }),
+    ];
+    const result = generateSkillsIndex(files, BASE);
+    expect(result).not.toBeNull();
+    expect(result!.html).toContain('href="/flicky/skills/Research/SKILL/index.html"');
+    expect(result!.html).not.toContain('href="/skills/Research/SKILL/index.html"');
+  });
+
+  test('generateHooksIndex prefixes hrefs with baseUrl', () => {
+    const files: ProcessedFile[] = [
+      mkFile({
+        type: 'hook',
+        title: 'PRDSync',
+        relativePath: 'hooks/PRDSync.hook.ts',
+        outputPath: 'hooks/PRDSync.hook/index.html',
+        metadata: { trigger: 'PostToolUse', purpose: 'Sync PRD to work.json' },
+      }),
+    ];
+    const result = generateHooksIndex(files, BASE);
+    expect(result).not.toBeNull();
+    expect(result!.html).toContain('href="/flicky/hooks/PRDSync.hook/index.html"');
+    expect(result!.html).not.toContain('href="/hooks/PRDSync.hook/index.html"');
+  });
+
+  test('generateDirectoryIndexes prefixes hrefs with baseUrl', () => {
+    const navTree: NavNode = {
+      name: 'root',
+      path: '',
+      isDirectory: true,
+      children: [
+        {
+          name: 'agents',
+          path: 'agents',
+          isDirectory: true,
+          children: [
+            {
+              name: 'Designer.md',
+              path: 'agents/Designer.md',
+              isDirectory: false,
+              outputPath: 'agents/Designer/index.html',
+              title: 'Designer',
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const indexes = generateDirectoryIndexes([], navTree, BASE);
+    expect(indexes.length).toBeGreaterThan(0);
+    const agentsDir = indexes.find(i => i.outputPath === 'agents/index.html');
+    expect(agentsDir).toBeDefined();
+    expect(agentsDir!.html).toContain('href="/flicky/agents/Designer/index.html"');
+    expect(agentsDir!.html).not.toContain('href="/agents/Designer/index.html"');
+  });
+});

--- a/src/tests/link-checker.test.ts
+++ b/src/tests/link-checker.test.ts
@@ -145,6 +145,23 @@ describe('checkLinks', () => {
     }
   });
 
+  test('issue #15 — site-absolute href with sitePrefix does not double-prefix', () => {
+    // Production shape: outputDir is the per-site prefix dir, and hrefs
+    // already contain the /<sitePrefix>/ segment from link-rewriter.
+    const parent = makeTempSite();
+    try {
+      const siteDir = join(parent, 'siteA');
+      mkdirSync(siteDir);
+      writeFileSync(join(siteDir, 'index.html'), '<a href="/siteA/page.html">link</a>');
+      writeFileSync(join(siteDir, 'page.html'), '<p>target</p>');
+      const result = checkLinks(siteDir, 'siteA');
+      expect(result.total).toBe(1);
+      expect(result.broken).toHaveLength(0);
+    } finally {
+      rmSync(parent, { recursive: true });
+    }
+  });
+
   test('empty output directory returns zero total', () => {
     const dir = makeTempSite();
     try {


### PR DESCRIPTION
## Summary

Two coupled bugs that together made the build's broken-link reporting useless and produced ~2700 real broken links per build.

- **#16** — Index generators (`agents`, `skills`, `hooks`, `directory`) emitted hrefs like `/agents/Designer/index.html`, missing the `/<prefix>/` segment. Threaded `baseUrl` into each generator; hrefs are now `baseUrl + '/' + outputPath`.
- **#15** — `checkLinks` joined site-absolute hrefs against the per-site `prefixDir`, producing doubled paths (`/flicky/flicky/...`) and reporting 99.7% false positives. Added `sitePrefix` param; strips `/<prefix>/` from absolute hrefs before joining.

`link-rewriter.ts` is untouched — its `/`-prefix short-circuit is the right behavior once index generators stop emitting unprefixed hrefs.

## Impact (full flicky build, ~/.claude, 2702 pages)

| | Before | After |
|---|---|---|
| Links total | 4,751,985 | 4,824,504 |
| Broken | **4,738,307** | **86** |
| Broken % | 99.7% | 0.0018% |

The remaining 86 broken links are all content-level #17 cases (node_modules `CONTRIBUTING.md`, literal example hrefs, extensionless TOC links, content `.md` paths that don't map to rendered pages) — out of scope for this PR.

## Changes

```
 src/build.ts                     |  12 ++---
 src/indexes/agents-index.ts      |   4 +-
 src/indexes/directory-index.ts   |   6 +--
 src/indexes/hooks-index.ts       |   4 +-
 src/indexes/skills-index.ts      |   4 +-
 src/link-checker.ts              |  12 ++++-
 src/tests/indexes-prefix.test.ts | 108 +++++++++++++++++++++++++++++++++++++++
 src/tests/link-checker.test.ts   |  17 ++++++
 8 files changed, 150 insertions(+), 17 deletions(-)
```

- `baseUrl` computation moved from build.ts:128 up to just after `prefix` is derived (line ~31), so it's in scope for the index generator calls at lines 104-106 and 118.
- Both new params (`sitePrefix`, `baseUrl`) default to empty string, preserving backward compat for any caller that doesn't pass them. All existing 181 tests still pass unchanged.

## New tests

- `src/tests/indexes-prefix.test.ts` (new file, 4 tests) — one per generator, asserts emitted href starts with `baseUrl + '/'` given a non-empty baseUrl.
- `src/tests/link-checker.test.ts` (+17 lines) — regression test matching the production shape the existing tests missed: `outputDir = <root>/siteA`, href `/siteA/page.html`, expects 0 broken. This is the shape that #15 hit in prod; the old "absolute link" test used a flat outputDir with no prefix and passed against buggy code.

## Test plan

- [x] `bun test` — 186 pass / 0 fail (181 prior + 5 new)
- [x] Full build of `~/.claude` as `flicky` — 86 broken (vs 4,738,307), all known content-level #17 cases
- [x] Spot-check: `/tmp/cg-verify/flicky/agents/Designer/index.html` exists on disk
- [x] Spot-check: `agents-index/index.html` hrefs start with `/flicky/agents/` (24 entries, all correct)
- [x] `link-rewriter.ts` NOT modified (anti-criterion)
- [x] Single-site/empty-prefix path not regressed (`nameToPrefix` fallback `'site'` means `baseUrl` is always well-formed)

Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)