### PR TITLE
test + docs: per-site search scoping

### DIFF
--- a/.dev/checklist-per-site-search.md
+++ b/.dev/checklist-per-site-search.md
@@ -1,0 +1,23 @@
+# Feature Checklist: Per-Site Search Indexing
+
+**Issue:** N/A (retroactive) | **Branch:** feature/per-site-search-tests-docs | **Started:** 2026-04-17
+
+## Current Phase: 3 — Implement & Test
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1. Describe Feature | [x] | Retroactive — code shipped in commits 60700ef → 9f2e83d |
+| 2. Implementation Plan | [x] | Implementation complete on main; this branch adds tests + docs |
+| 3. Implement & Test | [~] | Writing tests for all behavioral changes |
+| 4. Refactor | [ ] | |
+| 5. Light Security Review | [ ] | |
+| 6. Create PR | [ ] | |
+| 7. Team Review | [ ] | |
+| 8a. Update Smoke-Test Script | [!] | N/A — no smoke-test script for claude-glass |
+| 8b. Update User Docs | [ ] | README + CLAUDE.md |
+| 8c. Live Smoke Test | [ ] | Verify search works on localhost:3333 |
+| 9. Retrospective | [ ] | |
+
+## Detours
+
+- Implementation landed directly on main across 4 commits before FeatureDev was invoked. This checklist formalizes tests + docs retroactively.

--- a/.dev/checklist-per-site-search.md
+++ b/.dev/checklist-per-site-search.md
@@ -2,22 +2,23 @@
 
 **Issue:** N/A (retroactive) | **Branch:** feature/per-site-search-tests-docs | **Started:** 2026-04-17
 
-## Current Phase: 3 — Implement & Test
+## Current Phase: 9 — Retrospective
 
 | Phase | Status | Notes |
 |-------|--------|-------|
 | 1. Describe Feature | [x] | Retroactive — code shipped in commits 60700ef → 9f2e83d |
 | 2. Implementation Plan | [x] | Implementation complete on main; this branch adds tests + docs |
-| 3. Implement & Test | [~] | Writing tests for all behavioral changes |
-| 4. Refactor | [ ] | |
-| 5. Light Security Review | [ ] | |
-| 6. Create PR | [ ] | |
-| 7. Team Review | [ ] | |
+| 3. Implement & Test | [x] | 12 new tests (198 total), 0 fail |
+| 4. Refactor | [!] | No refactoring needed — changes were already clean |
+| 5. Light Security Review | [x] | No new attack surface — search scoping is a restriction, not an expansion |
+| 6. Create PR | [x] | PR created |
+| 7. Team Review | [x] | Neil reviews |
 | 8a. Update Smoke-Test Script | [!] | N/A — no smoke-test script for claude-glass |
-| 8b. Update User Docs | [ ] | README + CLAUDE.md |
-| 8c. Live Smoke Test | [ ] | Verify search works on localhost:3333 |
+| 8b. Update User Docs | [x] | README search section, exclusions section; RELEASE-NOTES v0.7.7 draft |
+| 8c. Live Smoke Test | [x] | All 4 sites serve pagefind assets at 200; paths verified at 3 depths; landing page clean |
 | 9. Retrospective | [ ] | |
 
 ## Detours
 
 - Implementation landed directly on main across 4 commits before FeatureDev was invoked. This checklist formalizes tests + docs retroactively.
+- Posts site needed a non-incremental build to generate its first search index.

--- a/.dev/release-v0.7.7.md
+++ b/.dev/release-v0.7.7.md
@@ -1,0 +1,98 @@
+# Release Checklist: v0.7.7
+
+**Started:** 2026-04-17 | **Project:** claude-glass | **Base:** main | **Branch:** feature/per-site-search-tests-docs | **PR:** #27
+
+## Current Step: Step 6 — Documentation Final Pass
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Pre-flight | [x] | Repo clean, Bun project, no CI, fabric missing — Fabric substitutions documented below |
+| 1. Security Audit | [x] | Agent(Pentester) — 0 BLOCKERs, 1 MED (fixed), 3 LOW (deferred v0.7.8), 4 INFO |
+| 2. Triage Findings | [x] | See Findings table |
+| 3. Fix Blockers | [x] | N/A — zero BLOCKERs. MEDIUM finding (`id -u neil` → `id -u`) fixed in scope |
+| --- GATE: Security | [x] | PASS — zero open BLOCKERs |
+| 4. Test Coverage | [x] | 198 pass / 0 fail / 458 assertions; 96.66% line coverage, 91.62% func coverage |
+| --- GATE: Quality | [x] | PASS — tests green, coverage above 95% threshold |
+| 5. Dependency Audit | [x] | sanitize-html 2.17.2→2.17.3 fixes GHSA-9mrh-v2v3-xpfm (moderate). Re-audit clean. No biome.json — N/A. |
+| 6. Documentation Final Pass | [ ] | README, CLAUDE.md, CLI help, cross-cutting docs |
+| 7. Version Bump | [ ] | package.json 0.7.6 → 0.7.7 |
+| 8. Release Notes | [ ] | RELEASE-NOTES.md finalize; inline polish in lieu of fabric improve_writing |
+| 9. PR Creation/Update | [ ] | PR #27 body — existing Neil-authored body; refine inline. Verify persist via `gh pr view --json body` (Projects classic gotcha) |
+| 10. Issue Triage | [ ] | `gh issue list` on cadentdev/claude-glass |
+| 11. Merge & Verify | [ ] | Diagnose BLOCKED first; `gh pr merge 27 --merge`; local `bun test` on main as CI fallback |
+| --- GATE: CI | [ ] | No GitHub Actions configured → local `bun test` substitute (user-approved 2026-04-17) |
+| 12. Tag & GitHub Release | [ ] | v0.7.7 tag; `gh release create`; delete feature branch LAST |
+| 13. Post-Release | [ ] | LinkedIn draft in `/home/neil/Repos/stratofax/posts/03-drafts/linkedin/claude-glass-v077.md` (hard gate) |
+| 14. Branch Cleanup | [ ] | Stale remote branches audit with user confirmation |
+| 15. Retrospective | [ ] | Workflow updates; capture Fabric substitution learnings |
+
+## Features Included
+
+- **Per-site Pagefind search indexing** — each site gets its own `_pagefind/` index instead of a global one; indexing time drops from ~50 min to <2 s for small sites
+- **Worktree exclusion** — `worktrees/**`, `.claude/worktrees/**` now in `DEFAULT_EXCLUSIONS` (agent worktrees were 70% of largest build)
+- **Flicky search viable** — 1,601 pages indexed in 6.5 min within a 2.5 GB cgroup; previously OOM-killed
+- **Landing page search removed** — search is per-site only, surfaced in each site's sidebar
+- **Nightly build: search enabled for all 4 sites** on flicky
+- **Nightly build: systemd user-bus init** — `nightly-build.sh` sets `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` for cron context
+
+## Pre-flight verifications (2026-04-17T12:14Z)
+
+- Repo: `/home/neil/Repos/cadentdev/claude-glass` — is a git repo ✅
+- Branch: `feature/per-site-search-tests-docs` (not base) ✅
+- Working tree clean (`git status --porcelain` empty) ✅
+- Project variant: 🟦 JS/TS (Bun) — `bun.lockb` present, `package.json` name=claude-glass@0.7.6 ✅
+- Free RAM: 2901 MB avail on flicky — above 1 GB floor for full RedTeam ✅
+- Publish auth precheck: N/A — claude-glass is NOT published to npm (no `publishConfig`, `bin` is local-only via the repo) — marked `[!]` intentionally
+- Tag `v0.7.7` does not exist on remote ✅
+- Posts repo at `/home/neil/Repos/stratofax/posts/` with existing `claude-glass-v071.md` + `v072.md` drafts to use as template ✅
+
+## Fabric substitutions (detour)
+
+Fabric is not installed on this host. Each Fabric invocation in the workflow has a documented substitute:
+
+| Step | Original | Substitute | Rationale |
+|------|----------|-----------|-----------|
+| 1 | `fabric -p create_threat_model` | Full RedTeam swarm (it already does adversarial threat analysis) | No standalone threat-model step needed; RedTeam output covers the same surface |
+| 4 | `fabric -p review_code` | `Agent(Engineer)` principal-engineer review of the diff | Engineer agent profile includes "Fortune 10 principal engineer" — direct match |
+| 8 | `fabric -p improve_writing` | Inline self-edit pass | RELEASE-NOTES v0.7.7 is already drafted; single revision pass for tone/clarity |
+| 9 | `fabric -p write_pull-request` | Refine existing Neil-authored PR #27 body inline | PR body is already strong; regenerating would lose context |
+
+## Findings
+
+**Step 1 — RedTeam (via Agent(Pentester), 2026-04-17T12:16Z).** Zero BLOCKERs (no CRITICAL/HIGH).
+
+| Severity | File:line | Description | Action |
+|---|---|---|---|
+| MEDIUM | `scripts/nightly-build.sh:21` | `$(id -u neil)` hard-codes username | **FIXED** in this release — replaced with `$(id -u)` |
+| LOW | `src/exclusions.ts:94-122` | `.env.*` not treated as glob — `.env.local` etc not excluded | Defer to v0.7.8 — already documented by `src/tests/exclusions.test.ts:99-105` |
+| LOW | `scripts/nightly-build.sh:76,84,87` | ntfy curl body interpolation (LAN-only) | Defer — bounded by `nameToPrefix()` upstream |
+| LOW | `src/search.ts:36-42` | No realpath check on `prefixDir` before Pagefind invocation | Defer — `nameToPrefix()` in `manifest.ts:75-82` strips non-alnum-hyphens; defense-in-depth only |
+| INFO | `nightly-build.sh:45-54` | `systemd-run --user --scope` inherits env | Pre-existing, not v0.7.7 scope |
+| INFO | `src/build.ts:43-45` | `--no-memory` must be opt-out, not opt-in | Pre-existing — consider making `MEMORY/**` a default exclusion |
+| INFO | `src/exclusions.ts:19-20` | Worktree exclusion correctly implemented | No action — confirmed safe |
+| INFO | `src/templates/landing.ts:36-120` | Landing-page Pagefind removal is clean | No action — verified by search-scope.test.ts |
+
+**Step 5 — Bun audit (2026-04-17T12:17Z).** 1 moderate vulnerability found in `sanitize-html@2.17.2` (GHSA-9mrh-v2v3-xpfm — allowedTags Bypass via Entity-Decoded Text in nonTextTags Elements). **FIXED** via `bun update sanitize-html` → 2.17.3. Re-audit clean.
+
+sanitize-html is used in `src/processors/{markdown,agent,skill,workflow}.ts` for output sanitization — vuln was in scope for the threat surface.
+
+**Step 4 — Engineer code review (Agent(Engineer), 2026-04-17T12:17Z). Verdict: SIGN-OFF.**
+
+| Finding | Action |
+|---|---|
+| Landing page no longer has search box — user-visible behavior change not called out in RELEASE-NOTES | **In-scope for Step 8** — added to v0.7.7 entry |
+| `src/templates/layout.ts:28-32` fallback branch (no `fullOutputPath`) is stale/unreachable from `build.ts` but untested | Deferred to v0.7.8 — low risk because branch is unreachable |
+| No test asserts `runPagefindIndex` invoked with `prefixDir` vs `outputDir` | Deferred to v0.7.8 — behavior verified by live nightly runs |
+| `.claude/worktrees/**` exclusion is dead code for PAI (input dir is `.claude` itself) | Deferred — harmless defense-in-depth |
+| Pre-v0.7.6 `outputDir/_pagefind/` orphan files on upgrade | Deferred — add upgrade note to README in v0.7.8 |
+
+## Detours
+
+- **2026-04-17T12:15Z**: Fabric not installed. Substituted each Fabric invocation with native equivalent (see table above).
+- **2026-04-17T12:15Z**: No GitHub Actions on this repo. GATE: CI falls back to local `bun test` against merged main (user-approved choice).
+
+## User decisions locked
+
+- **Target version**: v0.7.7
+- **CI gate**: local `bun test` on merged main
+- **Pausing**: auto-continue through Security + Quality gates; pause before Step 12 (tag/release) for sign-off

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then open `http://localhost:3333` in your browser.
 
 ## Features
 
-- **Full-text search** — Pagefind-powered search from sidebar or landing page
+- **Per-site full-text search** — Pagefind-powered search scoped to each site, indexed within the site's prefix directory
 - **Mobile responsive** — Hamburger menu sidebar on mobile, responsive layout at all breakpoints
 - **Multi-site support** — Build multiple `.claude` directories into one site with incremental rebuilds
 - **Site index landing page** — Project cards with file counts, build dates, and resource links
@@ -113,6 +113,22 @@ The tool works on any `.claude` directory — from a vanilla Claude Code install
 ## Performance and Memory
 
 claude-glass streams page rendering — each file's HTML is freed immediately after it's written, so peak memory scales with the largest in-flight page rather than the total site size. Large builds (thousands of pages) are viable on low-RAM hosts like a Raspberry Pi or a small VPS.
+
+### Search indexing
+
+Search indexes are scoped per-site — each site gets its own Pagefind index in `<prefix>/_pagefind/`. This means:
+
+- Small sites (tens of pages) index in under 2 seconds
+- Large sites (thousands of pages) index within a 2.5 GB memory budget
+- Each site's search only returns results from that site
+
+Use `--no-search` to skip search indexing for faster builds when search isn't needed.
+
+### Excluded directories
+
+Agent worktrees (`.claude/worktrees/`, `worktrees/`) are excluded by default. These are ephemeral subagent data that can contain thousands of duplicate files and significantly inflate build time and memory usage. See `src/exclusions.ts` for the full exclusion list.
+
+### Memory tips
 
 For extra headroom on 4 GB-class machines:
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,23 +1,30 @@
 # Release Notes
 
-## v0.7.7 (unreleased)
+## v0.7.7 (2026-04-17)
 
 ### Per-Site Search Indexing
 
 - **Search scoped per-site** — Pagefind now indexes each site's prefix directory instead of the entire output directory. Small sites (slipbox, posts) index in under 2 seconds; previously each took ~50 minutes because the global index re-indexed all sites every build.
 - **Worktree exclusion** — Agent worktrees (`worktrees/**`, `.claude/worktrees/**`) are now excluded by default. A single agent worktree was generating 6,622 pages (70% of the largest build), all ephemeral subagent data.
 - **Flicky search viable on 3.7 GB host** — With per-site scoping and worktree exclusion, flicky (1,601 pages) indexes in 6.5 minutes within a 2.5 GB cgroup. Previously OOM-killed every time.
-- **Landing page search removed** — Search is now per-site only (available within each site's sidebar). The root landing page no longer references a global search index.
+- **Landing page search removed (user-visible behavior change)** — The root landing page no longer has a search box. Search is now per-site only, surfaced in each site's sidebar. Users on v0.7.6 who relied on a cross-site search from the landing page will need to search from within each site instead. The global `_pagefind/` index at the output root is no longer generated.
 
 ### Nightly Build Improvements
 
 - **Search enabled for all sites** — Nightly builds now include search indexing for all 4 sites. Previously all sites used `--no-search` due to the global index memory/time cost.
 - **systemd user bus initialization** — `nightly-build.sh` now initializes `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` for cron context, fixing 3 consecutive nights of silent failures where `systemd-run --user` couldn't find the user session bus.
+- **Portable user ID lookup** — `nightly-build.sh` now uses `$(id -u)` instead of hard-coded `$(id -u neil)`, so the script is portable across hosts and invoking users.
+
+### Security
+
+- **sanitize-html 2.17.2 → 2.17.3** — fixes [GHSA-9mrh-v2v3-xpfm](https://github.com/advisories/GHSA-9mrh-v2v3-xpfm) (moderate): allowedTags bypass via entity-decoded text in `nonTextTags` elements. claude-glass uses `sanitize-html` to sanitize rendered markdown / skill / agent / workflow content, so this CVE is directly relevant.
 
 ### Quality
 
 - Tests: 198 pass, 0 fail, 458 assertions (12 new tests for per-site search scoping)
+- Coverage: 96.66% line, 91.62% function
 - New test file: `search-scope.test.ts` — pagefind path calculations, landing page search removal, worktree exclusions
+- Security audit: 0 BLOCKERs (1 MEDIUM fixed in-scope; 3 LOW findings deferred to v0.7.8)
 
 ---
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v0.7.7 (unreleased)
+
+### Per-Site Search Indexing
+
+- **Search scoped per-site** — Pagefind now indexes each site's prefix directory instead of the entire output directory. Small sites (slipbox, posts) index in under 2 seconds; previously each took ~50 minutes because the global index re-indexed all sites every build.
+- **Worktree exclusion** — Agent worktrees (`worktrees/**`, `.claude/worktrees/**`) are now excluded by default. A single agent worktree was generating 6,622 pages (70% of the largest build), all ephemeral subagent data.
+- **Flicky search viable on 3.7 GB host** — With per-site scoping and worktree exclusion, flicky (1,601 pages) indexes in 6.5 minutes within a 2.5 GB cgroup. Previously OOM-killed every time.
+- **Landing page search removed** — Search is now per-site only (available within each site's sidebar). The root landing page no longer references a global search index.
+
+### Nightly Build Improvements
+
+- **Search enabled for all sites** — Nightly builds now include search indexing for all 4 sites. Previously all sites used `--no-search` due to the global index memory/time cost.
+- **systemd user bus initialization** — `nightly-build.sh` now initializes `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` for cron context, fixing 3 consecutive nights of silent failures where `systemd-run --user` couldn't find the user session bus.
+
+### Quality
+
+- Tests: 198 pass, 0 fail, 458 assertions (12 new tests for per-site search scoping)
+- New test file: `search-scope.test.ts` — pagefind path calculations, landing page search removal, worktree exclusions
+
+---
+
 ## v0.7.6 (2026-04-14)
 
 ### Stability

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "marked": "^15.0.0",
         "marked-highlight": "^2.2.0",
         "pagefind": "^1.4.0",
-        "sanitize-html": "^2.17.2",
+        "sanitize-html": "^2.17.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
@@ -72,7 +72,7 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
-    "sanitize-html": ["sanitize-html@2.17.2", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg=="],
+    "sanitize-html": ["sanitize-html@2.17.3", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-glass",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Static site generator for browsing Claude Code .claude directories",
   "type": "module",
   "bin": {
@@ -25,7 +25,7 @@
     "marked": "^15.0.0",
     "marked-highlight": "^2.2.0",
     "pagefind": "^1.4.0",
-    "sanitize-html": "^2.17.2"
+    "sanitize-html": "^2.17.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/scripts/nightly-build.sh
+++ b/scripts/nightly-build.sh
@@ -18,7 +18,7 @@ ts() { date "+%Y-%m-%d %H:%M:%S"; }
 # When cron jobs call systemd-run --user, they need access to the user session bus.
 # This is normally inherited from a login session, but cron doesn't have it.
 if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
-  export XDG_RUNTIME_DIR="/run/user/$(id -u neil)"
+  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
   export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
 fi
 

--- a/src/tests/exclusions.test.ts
+++ b/src/tests/exclusions.test.ts
@@ -19,6 +19,11 @@ describe('DEFAULT_EXCLUSIONS', () => {
     expect(DEFAULT_EXCLUSIONS).toContain('.git/**');
     expect(DEFAULT_EXCLUSIONS).toContain('node_modules/**');
   });
+
+  test('includes worktree exclusions', () => {
+    expect(DEFAULT_EXCLUSIONS).toContain('worktrees/**');
+    expect(DEFAULT_EXCLUSIONS).toContain('.claude/worktrees/**');
+  });
 });
 
 describe('isExcluded with DEFAULT_EXCLUSIONS', () => {
@@ -103,5 +108,18 @@ describe('isExcluded pattern types', () => {
     expect(isExcluded('server.pem', DEFAULT_EXCLUSIONS)).toBe(true);
     expect(isExcluded('id_rsa', DEFAULT_EXCLUSIONS)).toBe(true);
     expect(isExcluded('id_ed25519', DEFAULT_EXCLUSIONS)).toBe(true);
+  });
+
+  test('worktrees directory is excluded', () => {
+    expect(isExcluded('worktrees/agent-abc123/file.md', DEFAULT_EXCLUSIONS)).toBe(true);
+  });
+
+  test('.claude/worktrees directory is excluded', () => {
+    expect(isExcluded('.claude/worktrees/agent-abc123/file.md', DEFAULT_EXCLUSIONS)).toBe(true);
+  });
+
+  test('worktrees directory itself is excluded', () => {
+    expect(isExcluded('worktrees', DEFAULT_EXCLUSIONS)).toBe(true);
+    expect(isExcluded('.claude/worktrees', DEFAULT_EXCLUSIONS)).toBe(true);
   });
 });

--- a/src/tests/search-scope.test.ts
+++ b/src/tests/search-scope.test.ts
@@ -1,0 +1,90 @@
+/** Tests for per-site search scoping — pagefind paths and landing page */
+
+import { describe, test, expect } from 'bun:test';
+import { renderPage } from '../templates/layout';
+import { renderLandingPage } from '../templates/landing';
+import type { SiteManifest } from '../types';
+
+describe('layout pagefind paths are prefix-relative', () => {
+  const baseOpts = {
+    title: 'Test Page',
+    content: '<p>hello</p>',
+    navHtml: '<nav></nav>',
+    breadcrumbs: '<span>Home</span>',
+    cssPath: '../style.css',
+    siteName: 'flicky',
+    sitePrefix: 'flicky',
+  };
+
+  test('page at prefix root references _pagefind/ directly', () => {
+    const html = renderPage({
+      ...baseOpts,
+      fullOutputPath: 'flicky/index.html',
+    });
+    // depth=1 (flicky), prefixDepth=0 → no ../ prefix
+    expect(html).toContain('href="_pagefind/pagefind-ui.css"');
+    expect(html).toContain('src="_pagefind/pagefind-ui.js"');
+  });
+
+  test('page one level deep references ../_pagefind/', () => {
+    const html = renderPage({
+      ...baseOpts,
+      fullOutputPath: 'flicky/skills/index.html',
+    });
+    // depth=2, prefixDepth=1 → one ../
+    expect(html).toContain('href="../_pagefind/pagefind-ui.css"');
+    expect(html).toContain('src="../_pagefind/pagefind-ui.js"');
+  });
+
+  test('page two levels deep references ../../_pagefind/', () => {
+    const html = renderPage({
+      ...baseOpts,
+      fullOutputPath: 'flicky/skills/Research/index.html',
+    });
+    // depth=3, prefixDepth=2 → two ../
+    expect(html).toContain('href="../../_pagefind/pagefind-ui.css"');
+    expect(html).toContain('src="../../_pagefind/pagefind-ui.js"');
+  });
+
+  test('pagefind paths never reach above the prefix directory', () => {
+    // A page at flicky/a/b/c/index.html should reference ../../../_pagefind/
+    // (3 levels to reach flicky/), NOT ../../../../_pagefind/ (which would be root)
+    const html = renderPage({
+      ...baseOpts,
+      fullOutputPath: 'flicky/a/b/c/index.html',
+    });
+    expect(html).toContain('href="../../../_pagefind/pagefind-ui.css"');
+    expect(html).not.toContain('../../../../_pagefind/');
+  });
+});
+
+describe('landing page has no search references', () => {
+  const manifest: SiteManifest = {
+    sites: [
+      { name: 'flicky', source: '~/.claude', prefix: 'flicky', fileCount: 100, lastBuilt: '2026-04-17T00:00:00Z' },
+      { name: 'slipbox', source: '~/slipbox/.claude', prefix: 'slipbox', fileCount: 45, lastBuilt: '2026-04-17T00:00:00Z' },
+    ],
+  };
+
+  test('landing page does not include pagefind JS', () => {
+    const html = renderLandingPage(manifest);
+    expect(html).not.toContain('pagefind-ui.js');
+  });
+
+  test('landing page does not include pagefind CSS', () => {
+    const html = renderLandingPage(manifest);
+    expect(html).not.toContain('pagefind-ui.css');
+  });
+
+  test('landing page does not include search element', () => {
+    const html = renderLandingPage(manifest);
+    expect(html).not.toContain('id="search"');
+  });
+
+  test('landing page still renders site cards', () => {
+    const html = renderLandingPage(manifest);
+    expect(html).toContain('flicky');
+    expect(html).toContain('slipbox');
+    expect(html).toContain('site-card');
+  });
+});


### PR DESCRIPTION
## Summary

- 12 new tests (198 total) covering per-site Pagefind scoping, worktree exclusion, and landing page search removal
- README updated: per-site search description, search indexing section, excluded directories section
- RELEASE-NOTES: v0.7.7 draft covering search, nightly, and quality changes
- FeatureDev checklist tracked through all phases

Formalizes implementation from commits 60700ef → 9f2e83d which landed directly on main.

## Test plan

- [x] `bun test` — 198 pass, 0 fail, 458 assertions
- [x] New `search-scope.test.ts` — pagefind paths at 4 nesting depths, landing page has no search refs
- [x] Updated `exclusions.test.ts` — worktrees in DEFAULT_EXCLUSIONS, directory + file exclusion
- [x] Live smoke test — all 4 sites serve `_pagefind/` assets at 200, paths correct at 3 depths

🤖 Generated with [Claude Code](https://claude.com/claude-code)