### PR TITLE
fix: normalize backslash paths to forward slashes on Windows

### DIFF
--- a/src/exclusions.ts
+++ b/src/exclusions.ts
@@ -92,8 +92,10 @@ export const DEFAULT_EXCLUSIONS = [
  * Supports ** glob patterns and simple filename matches.
  */
 export function isExcluded(relativePath: string, exclusions: string[]): boolean {
+  // Normalize backslashes to forward slashes for consistent pattern matching on Windows
+  const normalized = relativePath.replace(/\\/g, '/');
   for (const pattern of exclusions) {
-    if (matchPattern(relativePath, pattern)) return true;
+    if (matchPattern(normalized, pattern)) return true;
   }
   return false;
 }

--- a/src/link-rewriter.ts
+++ b/src/link-rewriter.ts
@@ -39,8 +39,9 @@ export function rewriteInternalLinks(
       }
 
       // Try to resolve the relative link against the current file's directory
-      const currentDir = dirname(currentRelativePath);
-      const resolved = normalize(join(currentDir, href));
+      // Normalize backslashes to forward slashes — dirname/join/normalize produce backslashes on Windows
+      const currentDir = dirname(currentRelativePath).replace(/\\/g, '/');
+      const resolved = normalize(join(currentDir, href)).replace(/\\/g, '/');
 
       // Strip any fragment
       const [pathPart, fragment] = resolved.split('#');

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -19,7 +19,7 @@ export function scan(inputDir: string, extraExclusions: string[] = []): ScanEntr
 
     for (const item of items) {
       const absolutePath = join(dir, item);
-      const relativePath = relative(inputDir, absolutePath);
+      const relativePath = relative(inputDir, absolutePath).replace(/\\/g, '/');
 
       if (isExcluded(relativePath, exclusions)) continue;
 


### PR DESCRIPTION
## Problem

On Windows, `path.relative()` produces backslashes (`rules\learned-rules.md`). These backslashes flow through the pipeline and break:

1. **Exclusion matching** — glob patterns use forward slashes, so `isExcluded()` never matches backslash paths. Result: ~710K broken links instead of ~2.3K.
2. **Link rewriting** — `dirname()`, `join()`, and `normalize()` reintroduce backslashes on Windows, producing URLs like `rules\learned-rules\index.html` instead of `rules/learned-rules/index.html`.

## Fix

Normalize backslashes to forward slashes at the root (`scanner.ts:relative()` output) and in the two consumers that reintroduce them via path operations (`link-rewriter.ts`, `exclusions.ts`).

3 files changed, 7 insertions, 4 deletions.

## Testing

Before fix: 710K+ broken links on Windows build.
After fix: 2,364 broken links (matching expected level for cross-referenced markdown repos).

Build output confirms the fix:
```
Links: 999483 total, 2364 broken
Built 1151 pages in 105.1s
```

Closes #28