### PR TITLE
fix: clear sanitize-html + postcss XSS advisories (+ Windows path fixes)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "marked": "^15.0.0",
         "marked-highlight": "^2.2.0",
         "pagefind": "^1.4.0",
-        "sanitize-html": "^2.17.3",
+        "sanitize-html": "^2.17.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
@@ -38,6 +38,8 @@
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -58,6 +60,8 @@
 
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
+    "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
+
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "marked-highlight": ["marked-highlight@2.2.3", "", { "peerDependencies": { "marked": ">=4 <18" } }, "sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ=="],
@@ -72,7 +76,7 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
-    "sanitize-html": ["sanitize-html@2.17.3", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg=="],
+    "sanitize-html": ["sanitize-html@2.17.4", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,9 @@
       },
     },
   },
+  "overrides": {
+    "postcss": "8.5.15",
+  },
   "packages": {
     "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ=="],
 
@@ -66,7 +69,7 @@
 
     "marked-highlight": ["marked-highlight@2.2.3", "", { "peerDependencies": { "marked": ">=4 <18" } }, "sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
 
@@ -74,7 +77,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "sanitize-html": ["sanitize-html@2.17.4", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "marked": "^15.0.0",
     "marked-highlight": "^2.2.0",
     "pagefind": "^1.4.0",
-    "sanitize-html": "^2.17.3"
+    "sanitize-html": "^2.17.4"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "@types/bun": "^1.3.11",
     "@types/sanitize-html": "^2.16.1"
+  },
+  "overrides": {
+    "postcss": "8.5.15"
   }
 }

--- a/src/exclusions.ts
+++ b/src/exclusions.ts
@@ -92,8 +92,10 @@ export const DEFAULT_EXCLUSIONS = [
  * Supports ** glob patterns and simple filename matches.
  */
 export function isExcluded(relativePath: string, exclusions: string[]): boolean {
+  // Normalize backslashes to forward slashes for consistent pattern matching on Windows
+  const normalized = relativePath.replace(/\\/g, '/');
   for (const pattern of exclusions) {
-    if (matchPattern(relativePath, pattern)) return true;
+    if (matchPattern(normalized, pattern)) return true;
   }
   return false;
 }

--- a/src/link-rewriter.ts
+++ b/src/link-rewriter.ts
@@ -39,8 +39,9 @@ export function rewriteInternalLinks(
       }
 
       // Try to resolve the relative link against the current file's directory
-      const currentDir = dirname(currentRelativePath);
-      const resolved = normalize(join(currentDir, href));
+      // Normalize backslashes to forward slashes — dirname/join/normalize produce backslashes on Windows
+      const currentDir = dirname(currentRelativePath).replace(/\\/g, '/');
+      const resolved = normalize(join(currentDir, href)).replace(/\\/g, '/');
 
       // Strip any fragment
       const [pathPart, fragment] = resolved.split('#');

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -19,7 +19,7 @@ export function scan(inputDir: string, extraExclusions: string[] = []): ScanEntr
 
     for (const item of items) {
       const absolutePath = join(dir, item);
-      const relativePath = relative(inputDir, absolutePath);
+      const relativePath = relative(inputDir, absolutePath).replace(/\\/g, '/');
 
       if (isExcluded(relativePath, exclusions)) continue;
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -44,9 +44,11 @@ export async function serve(config: BuildConfig): Promise<void> {
         return new Response('Not Found', { status: 404 });
       }
 
-      // Path containment: resolve symlinks and verify file is within output dir
-      const realPath = realpathSync(filePath);
-      const realOutputDir = realpathSync(config.outputDir);
+      // Path containment: resolve symlinks and verify file is within output dir.
+      // Normalize backslashes first: realpathSync returns backslash paths on Windows, which break
+      // the forward-slash startsWith() containment check (every file would 403). No-op on POSIX.
+      const realPath = realpathSync(filePath).replace(/\\/g, '/');
+      const realOutputDir = realpathSync(config.outputDir).replace(/\\/g, '/');
       if (!realPath.startsWith(realOutputDir + '/') && realPath !== realOutputDir) {
         return new Response('Forbidden', { status: 403 });
       }


### PR DESCRIPTION
> **Consolidates and supersedes #29 (Windows backslash fix) and #30 (sanitize-html 2.17.4).** All three overlapped. They're bundled here because claude-glass's pre-push test suite fails on Windows path bugs, so the security dependency fixes can't be pushed/verified green without the Windows path fixes included. Commits are atomic, so feel free to cherry-pick or ask to split.

Bundles the security dependency fixes with two Windows path-handling bug fixes.

## Security (dependency advisories)
- **sanitize-html 2.17.3 -> 2.17.4** — clears CVE-2026-44990, and GHSA-rpr9-rxv7-x643 (the `xmp` raw-text passthrough XSS that affects `=2.17.3`).
- **postcss pinned to 8.5.15** via `overrides` — clears GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>` in CSS stringify output; `postcss <8.5.10`, pulled transitively through sanitize-html).

`bun audit`: 0 vulnerabilities.

## Windows path fixes
- **link-rewriter / scanner / exclusions** — normalize backslashes to forward slashes (the commit from #29, "Fixes #28"). Without it `rewriteInternalLinks` leaves links unrewritten on Windows.
- **serve.ts containment check** — `realpathSync` returns backslash paths on Windows, so the forward-slash `startsWith(outputDir + '/')` containment check never matched and every file returned 403. Normalize both sides before comparing (no-op on POSIX). Path-containment security is preserved: the outside-dir symlink test still returns 403.

Full test suite: 198 pass / 0 fail.
